### PR TITLE
Build Headless Service for Multi-Host TPU Worker Pods

### DIFF
--- a/ray-operator/controllers/ray/common/service.go
+++ b/ray-operator/controllers/ray/common/service.go
@@ -264,6 +264,39 @@ func BuildServeService(rayService rayv1.RayService, rayCluster rayv1.RayCluster,
 	return serveService, nil
 }
 
+// BuildHeadlessService builds the headless service for workers in multi-host worker groups to communicate
+func BuildHeadlessServiceForRayCluster(rayCluster rayv1.RayCluster) (*corev1.Service, error) {
+	name := rayCluster.Name + utils.DashSymbol + utils.HeadlessServiceSuffix
+	namespace := rayCluster.Namespace
+
+	labels := map[string]string{
+		utils.RayClusterHeadlessServiceLabelKey: rayCluster.Name,
+	}
+	selectorLabels := map[string]string{
+		utils.RayClusterLabelKey:  rayCluster.Name,
+		utils.RayNodeTypeLabelKey: string(rayv1.WorkerNode),
+	}
+
+	default_namespace := namespace
+	default_type := corev1.ServiceTypeClusterIP
+	clusterIP := "None"
+
+	headlessService := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: default_namespace,
+			Labels:    labels,
+		},
+		Spec: corev1.ServiceSpec{
+			ClusterIP: clusterIP,
+			Selector:  selectorLabels,
+			Type:      default_type,
+		},
+	}
+
+	return headlessService, nil
+}
+
 func setServiceTypeForUserProvidedService(service *corev1.Service, default_type corev1.ServiceType) {
 	// If the user has not specified a service type, use the default service type
 	if service.Spec.Type == "" {

--- a/ray-operator/controllers/ray/raycluster_controller.go
+++ b/ray-operator/controllers/ray/raycluster_controller.go
@@ -594,6 +594,7 @@ func (r *RayClusterReconciler) reconcileHeadlessService(ctx context.Context, ins
 		}
 		// Check if there's an existing headless service in the cluster.
 		if len(services.Items) != 0 {
+			r.Log.Info("reconcileHeadlessService", "Headless service already created")
 			// service exists, do nothing
 			return nil
 		} else {
@@ -607,6 +608,7 @@ func (r *RayClusterReconciler) reconcileHeadlessService(ctx context.Context, ins
 			if err := r.createService(ctx, headlessSvc, instance); err != nil {
 				return err
 			}
+			r.Log.Info("reconcileHeadlessService", "Headless service created")
 		}
 	}
 

--- a/ray-operator/controllers/ray/raycluster_controller.go
+++ b/ray-operator/controllers/ray/raycluster_controller.go
@@ -330,6 +330,12 @@ func (r *RayClusterReconciler) rayClusterReconcile(ctx context.Context, request 
 		}
 		return ctrl.Result{RequeueAfter: DefaultRequeueDuration}, err
 	}
+	if err := r.reconcileHeadlessService(ctx, instance); err != nil {
+		if updateErr := r.updateClusterState(ctx, instance, rayv1.Failed); updateErr != nil {
+			r.Log.Error(updateErr, "RayCluster update state error", "cluster name", request.Name)
+		}
+		return ctrl.Result{RequeueAfter: DefaultRequeueDuration}, err
+	}
 	// Only reconcile the K8s service for Ray Serve when the "ray.io/enable-serve-service" annotation is set to true.
 	if enableServeServiceValue, exist := instance.Annotations[utils.EnableServeServiceKey]; exist && enableServeServiceValue == utils.EnableServeServiceTrue {
 		if err := r.reconcileServeService(ctx, instance); err != nil {
@@ -566,6 +572,45 @@ func (r *RayClusterReconciler) reconcileServeService(ctx context.Context, instan
 	} else {
 		return err
 	}
+}
+
+// Return nil only when the headless service for multi-host worker groups is successfully created or already exists.
+func (r *RayClusterReconciler) reconcileHeadlessService(ctx context.Context, instance *rayv1.RayCluster) error {
+	// Check if there are worker groups with NumOfHosts > 1 in the cluster
+	isMultiHost := false
+	for _, workerGroup := range instance.Spec.WorkerGroupSpecs {
+		if workerGroup.NumOfHosts > 1 {
+			isMultiHost = true
+			break
+		}
+	}
+
+	if isMultiHost {
+		services := corev1.ServiceList{}
+		filterLabels := client.MatchingLabels{utils.RayClusterLabelKey: instance.Name, utils.RayNodeTypeLabelKey: string(rayv1.WorkerNode)}
+
+		if err := r.List(ctx, &services, client.InNamespace(instance.Namespace), filterLabels); err != nil {
+			return err
+		}
+		// Check if there's an existing headless service in the cluster.
+		if len(services.Items) != 0 {
+			// service exists, do nothing
+			return nil
+		} else {
+			// Create headless tpu worker service if there's no existing one in the cluster.
+			headlessSvc, err := common.BuildHeadlessServiceForRayCluster(*instance)
+
+			if err != nil {
+				return err
+			}
+
+			if err := r.createService(ctx, headlessSvc, instance); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
 }
 
 func (r *RayClusterReconciler) reconcilePods(ctx context.Context, instance *rayv1.RayCluster) error {

--- a/ray-operator/controllers/ray/raycluster_controller_fake_test.go
+++ b/ray-operator/controllers/ray/raycluster_controller_fake_test.go
@@ -1047,6 +1047,66 @@ func TestReconcileHeadService(t *testing.T) {
 	assert.NotNil(t, err, "Reconciler should report an error when there are two head services")
 }
 
+func TestReconcileHeadlessService(t *testing.T) {
+	setupTest(t)
+
+	// Specify a multi-host worker group
+	testRayCluster.Spec.WorkerGroupSpecs[0].NumOfHosts = 4
+
+	// Mock data
+	cluster := testRayCluster.DeepCopy()
+
+	// Create a new scheme with CRDs, Pod, Service schemes.
+	newScheme := runtime.NewScheme()
+	_ = rayv1.AddToScheme(newScheme)
+	_ = corev1.AddToScheme(newScheme)
+
+	// Initialize a fake client with newScheme and runtimeObjects.
+	runtimeObjects := []runtime.Object{cluster}
+	fakeClient := clientFake.NewClientBuilder().WithScheme(newScheme).WithRuntimeObjects(runtimeObjects...).Build()
+	ctx := context.TODO()
+
+	// Initialize RayCluster reconciler.
+	r := &RayClusterReconciler{
+		Client:   fakeClient,
+		Recorder: &record.FakeRecorder{},
+		Scheme:   scheme.Scheme,
+		Log:      ctrl.Log.WithName("controllers").WithName("RayCluster"),
+	}
+
+	headlessServiceSelector := labels.SelectorFromSet(map[string]string{
+		utils.RayClusterHeadlessServiceLabelKey: cluster.Name,
+	})
+
+	// Case 1: Headless service does not exist.
+	err := r.reconcileHeadlessService(ctx, cluster)
+	assert.Nil(t, err, "Fail to reconcile head service")
+
+	// One headless service should be created.
+	serviceList := corev1.ServiceList{}
+	err = fakeClient.List(ctx, &serviceList, &client.ListOptions{
+		LabelSelector: headlessServiceSelector,
+		Namespace:     cluster.Namespace,
+	})
+	expectedName := cluster.Name + utils.DashSymbol + utils.HeadlessServiceSuffix
+	assert.Nil(t, err, "Fail to get service list")
+	assert.Equal(t, 1, len(serviceList.Items), "Service list len is wrong")
+	assert.Equal(t, expectedName, serviceList.Items[0].ObjectMeta.Name, "Headless Service name is wrong, expected %s actual %s", expectedName, serviceList.Items[0].ObjectMeta.Name)
+
+	// Case 2: Headless service already exists, nothing should be done
+	err = r.reconcileHeadlessService(ctx, cluster)
+	assert.Nil(t, err, "Fail to reconcile head service")
+
+	// The namespace should still have only one headless service.
+	serviceList = corev1.ServiceList{}
+	err = fakeClient.List(ctx, &serviceList, &client.ListOptions{
+		LabelSelector: headlessServiceSelector,
+		Namespace:     cluster.Namespace,
+	})
+	assert.Nil(t, err, "Fail to get service list")
+	assert.Equal(t, 1, len(serviceList.Items), "Service list len is wrong")
+}
+
 func contains(slice []string, item string) bool {
 	set := make(map[string]struct{}, len(slice))
 	for _, s := range slice {

--- a/ray-operator/controllers/ray/utils/constant.go
+++ b/ray-operator/controllers/ray/utils/constant.go
@@ -12,6 +12,7 @@ const (
 	RayNodeLabelKey                          = "ray.io/is-ray-node"
 	RayIDLabelKey                            = "ray.io/identifier"
 	RayClusterServingServiceLabelKey         = "ray.io/serve"
+	RayClusterHeadlessServiceLabelKey        = "ray.io/tpu-worker-svc"
 	HashWithoutReplicasAndWorkersToDeleteKey = "ray.io/hash-without-replicas-and-workers-to-delete"
 	NumWorkerGroupsKey                       = "ray.io/num-worker-groups"
 
@@ -74,8 +75,12 @@ const (
 	// The default name for kuberay operator
 	ComponentName = "kuberay-operator"
 
-	// The defaule RayService Identifier.
+	// The default RayService Identifier.
 	RayServiceCreatorLabelValue = "rayservice"
+
+	// The default suffix for Headless Service for multi-host worker groups.
+	// The full name will be of the form "${RayCluster_Name}-tpu-worker-svc".
+	HeadlessServiceSuffix = "tpu-worker-svc"
 
 	// Use as container env variable
 	RAY_CLUSTER_NAME                        = "RAY_CLUSTER_NAME"


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

In order to support Multi-Host TPU worker groups with Kuberay, it's necessary to build a headless service that exposes worker pods to allow pod-to-pod communication. This PR builds a headless service that selects for worker nodes in a RayCluster with `NumOfHosts > 1`. cc: @richardsliu @kevin85421 
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [x] Unit tests
   - [x] Manual tests
   - [ ] This PR is not tested :(
